### PR TITLE
영상 snippets 획득 로직 리펙토링

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -117,7 +117,7 @@ def fetch_videos_from_playlist(youtube, playlist_id):
 def fetch_video_snippets(youtube, video_ids):
     video_items = []
 
-    # video_ids split by 50 to avoid exceeding the limit
+    # Split video_ids by 50 to avoid exceeding the limit
     for i in range(math.ceil(len(video_ids) / 50)):
         video_request = youtube.videos().list(
             part="snippet",


### PR DESCRIPTION
# 목표

영상 snippets 획득 로직을 효율적으로 리펙토링 합니다.

# 설명 및 효과

영상의 snippets을 조회하기 위해 youtube에 api request을 보낼 때,
기존에는 for문으로 각각의 video id 에 대해 조회하는 request을 보내도록 구현되어 있습니다.

이를 한번에 여러개를(정책상 50개 씩) 조회하도록 수정하여, API 호출 비용(횟수)이나 속도 측면에서 성능을 개선합니다.
